### PR TITLE
Update retry_interceptor.dart

### DIFF
--- a/lib/src/retry_interceptor.dart
+++ b/lib/src/retry_interceptor.dart
@@ -81,7 +81,13 @@ class RetryInterceptor extends Interceptor {
     if (delay != Duration.zero) await Future<void>.delayed(delay);
 
     // ignore: unawaited_futures
-    dio.fetch<void>(err.requestOptions).then((value) => handler.resolve(value));
+    try {
+      await dio.fetch<void>(err.requestOptions).then((value) => handler.resolve(value));
+    } on DioError catch (e) {
+      super.onError(e, handler);
+    } catch (e) {
+      print('Retry error!!! $e');
+    }
   }
 
   Duration _getDelay(int attempt) {


### PR DESCRIPTION
fix retry uncatched error. if not, when error occurred, we can't catch error by dio.post or dio.get.